### PR TITLE
add websocketPort to public server list

### DIFF
--- a/public-servers.json
+++ b/public-servers.json
@@ -42,7 +42,7 @@
 		{
 			"id": 4,
 			"name": "Woogerworks",
-			"site": https://woogerworks.com/,
+			"site": "https://woogerworks.com/",
 			"host": "cockatrice.woogerworks.com",
 			"isInactive": true
 		}


### PR DESCRIPTION
See https://github.com/Cockatrice/Cockatrice/pull/3545

https://github.com/Cockatrice/Cockatrice/blob/master/cockatrice/src/handle_public_servers.cpp#L74

<br>

I also deprecated dr4ft server as it has been down for quite a while and added some cleanup.

TODO with merge: remove from wiki as well: https://github.com/Cockatrice/Cockatrice/wiki/Public-Servers