### PR TITLE
Update githubAPI.js

### DIFF
--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -13,7 +13,7 @@ $.getJSON(githubReleasesAPI, function (json) {
       if (url.includes('win64.exe')) {
         win64 = url
       }
-      else if (url.includes('macos10.14')) {
+      else if (url.includes('macos10.15')) {
         macOS_latest = url
       }
       else if (url.includes('macos10.13')) {


### PR DESCRIPTION
with changing to catalina this link was not updated https://github.com/Cockatrice/Cockatrice/pull/4059

might I mention this looks really bad to maintain?