### PR TITLE
Update news section with newest release automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
             <div class="news">
                <h3>News</h3>
                <ul id="news-list">
+                  <!-- Items listed here will be replaced with the newest release dynamically -->
                   <li>Read about the newest release <a href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">here</a>!</li>
                </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -54,14 +54,8 @@
             <!-- 'News' section -->
             <div class="news">
                <h3>News</h3>
-               <ul>
-                  <li><kbd>2025-02-10</kbd> <a href="https://github.com/Cockatrice/Cockatrice/releases/tag/2025-02-10-Release-2.10.0" target="_blank" rel="noreferrer">Cockatrice v2.10.0</a> released</li>
-                     <ul>
-                        <li>
-                        Don't see your OS on the sidebar?<br>
-                        View all available precompiled binaries <a href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">here</a>.
-                        </li>
-                     </ul>
+               <ul id="news-list">
+                  <li>Read about the newest release <a href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">here</a>!</li>
                </ul>
             </div>
             <br><br>

--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -1,34 +1,35 @@
 var githubReleasesAPI = "https://api.github.com/repos/Cockatrice/Cockatrice/releases/latest";
 
+// Update download links based on the latest release assets
 $.getJSON(githubReleasesAPI, function (json) {
-    var win64 = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    var macOS_latest = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    var macOS_legacy = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    var ubuntu = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    var debian = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    var fedora = 'https://github.com/Cockatrice/Cockatrice/releases/latest'
-    
+    var win64 = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+    var macOS_latest = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+    var macOS_legacy = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+    var ubuntu = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+    var debian = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+    var fedora = 'https://github.com/Cockatrice/Cockatrice/releases/latest';
+
     for (asset of json.assets) {
-      url = asset.browser_download_url
-      console.log(url);
-      if (url.includes('Win10')) {
-        win64 = url
-      }
-      else if (url.includes('macOS15')) {
-        macOS_latest = url
-      }
-      else if (url.includes('macOS14')) {
-        macOS_legacy = url
-      }
-      else if (url.includes('Ubuntu24')) {
-        ubuntu = url
-      }
-      else if (url.includes("Debian")) {
-        debian = url
-      }
-      else if (url.includes("Fedora")) {
-        fedora = url
-      }
+        url = asset.browser_download_url;
+        console.log(url);
+        if (url.includes('Win10')) {
+            win64 = url;
+        }
+        else if (url.includes('macOS15')) {
+            macOS_latest = url;
+        }
+        else if (url.includes('macOS14')) {
+            macOS_legacy = url;
+        }
+        else if (url.includes('Ubuntu24')) {
+            ubuntu = url;
+        }
+        else if (url.includes("Debian")) {
+            debian = url;
+        }
+        else if (url.includes("Fedora")) {
+            fedora = url;
+        }
     }
 
     $('#win64').attr('href', win64);
@@ -37,4 +38,17 @@ $.getJSON(githubReleasesAPI, function (json) {
     $('#ubuntu').attr('href', ubuntu);
     $('#debian').attr('href', debian);
     $('#fedora').attr('href', fedora);
+}).fail(function() {
+    console.error('Failed to fetch download links.');
+});
+
+// Update news section with the latest release information
+$.getJSON(githubReleasesAPI, function(json) {
+    var releaseName = json.name;
+    var releaseDate = new Date(json.published_at).toISOString().split('T')[0];
+    var releaseUrl = json.html_url;
+    var newsItem = `<li><kbd>${releaseDate}</kbd> <a href="${releaseUrl}" target="_blank" rel="noreferrer">${releaseName}</a> released!</li>`;
+    $('#news-list').html(newsItem);    // Replace static content with newest release item fetched
+}).fail(function() {
+    console.error('Failed to fetch release news.');
 });


### PR DESCRIPTION
Closes #19

The webpage has to be manually updated to announce and link to the most recent stable release.
Only the download links on the sidebar are fetched dynamically right now.

- Have static placeholder with link to latest release under `News`
  ![image](https://github.com/user-attachments/assets/01be428c-ba15-4dd5-9155-babde65f71ef)

- Replace placeholder dynamically with newest release
  ![image](https://github.com/user-attachments/assets/a2a2f030-03af-4f6e-9ad1-08c8f3516957)
