### PR TITLE
List macOS Intel build on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
             <div class="dlbox">
                <ul>
                   <li><a id="win64" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Windows</strong><sub>10 & newer</sub></a></li>
-                  <li><a id="macOS_latest" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>macOS</strong><sub>15 & newer</sub></a></li>
-                  <li><a id="macOS_legacy" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>macOS</strong><sub>14 & newer</sub></a></li>
+                  <li><a id="macOS_latest" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>macOS</strong><sub>Apple Silicon (15+)</sub></a></li>
+                  <li><a id="macOS_legacy" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>macOS</strong><sub>Intel (13+)</sub></a></li>
                </ul>
                <ul>
                   <li><a id="ubuntu" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Ubuntu</strong><sub>24.04 LTS</sub></a></li>

--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -18,7 +18,7 @@ $.getJSON(githubReleasesAPI, function (json) {
         else if (url.includes('macOS15')) {
             macOS_latest = url;
         }
-        else if (url.includes('macOS14')) {
+        else if (url.includes('macOS13')) {
             macOS_legacy = url;
         }
         else if (url.includes('Ubuntu24')) {


### PR DESCRIPTION
## Related Ticket(s)
https://github.com/Cockatrice/Cockatrice/issues/5006#issuecomment-2825216476

## Short roundup of the initial problem
The website currently lists two Apple Silicon builds (macOS 14 and macOS 15) and relegates the Intel build to the `All Available Downloads` link. All the other listed OS's have their single, latest available build listed. To my knowledge, the processor architecture is the more salient compatibility issue on Mac computers and users are more likely to need a specific architecture over a specific OS version.

## What will change with this Pull Request?
Link to the latest Apple Silicon build (macOS 15) and the latest Intel build (macOS 13) on the front page, to make it easier for users to find and to be more in line with how other OS's are listed.

## Related Thoughts
Since there is only one Intel build (and, I assume, will continue to be only one), would it make more sense to use `url.includes('Intel')` over `url.includes('macOS13')` to avoid having to update `githubAPI.js` again when the minimum version changes?

As always, do please let me know if I've missed some important technical or design nuance here; this is my first commit to this repo so I may be lacking context on how things are done or what else might need to change to accomplish this.
