### PR TITLE
Update download buttons for 3.0.0 release

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
                   <li><a id="macOS_legacy" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>macOS</strong><sub>13+ (Intel)</sub></a></li>
                </ul>
                <ul>
-                  <li><a id="ubuntu" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Ubuntu</strong><sub>24.04 LTS</sub></a></li>
+                  <li><a id="ubuntu" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Ubuntu</strong><sub>26.04 LTS</sub></a></li>
                   <li><a id="debian" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Debian</strong><sub>13</sub></a></li>
-                  <li><a id="fedora" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Fedora</strong><sub>43</sub></a></li>
+                  <li><a id="fedora" href="https://github.com/Cockatrice/Cockatrice/releases/latest" target="_blank" rel="noreferrer">Download <strong>Fedora</strong><sub>44</sub></a></li>
                </ul>
             </div>
             <p>

--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -21,7 +21,7 @@ $.getJSON(githubReleasesAPI, function (json) {
         else if (url.includes('macOS13')) {
             macOS_legacy = url;
         }
-        else if (url.includes('Ubuntu24')) {
+        else if (url.includes('Ubuntu')) {
             ubuntu = url;
         }
         else if (url.includes("Debian")) {

--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -21,7 +21,7 @@ $.getJSON(githubReleasesAPI, function (json) {
         else if (url.includes('macOS13')) {
             macOS_legacy = url;
         }
-        else if (url.includes('Ubuntu')) {
+        else if (url.includes('Ubuntu26')) {
             ubuntu = url;
         }
         else if (url.includes("Debian13")) {

--- a/javascript/githubAPI.js
+++ b/javascript/githubAPI.js
@@ -24,9 +24,9 @@ $.getJSON(githubReleasesAPI, function (json) {
         else if (url.includes('Ubuntu')) {
             ubuntu = url;
         }
-        else if (url.includes("Debian")) {
+        else if (url.includes("Debian13")) {
             debian = url;
-        }
+        } //version is hardcoded so as not to pick up servatrice debian by accident
         else if (url.includes("Fedora")) {
             fedora = url;
         }


### PR DESCRIPTION
## Short roundup of the initial problem

Cockatrice 3.0.0 newly builds for Ubuntu 26.04 and Fedora 44. The buttons on the download page do not reflect this. The API also does not know to look for the Ubuntu 26.04 build.

Additionally, the Debian button is getting the link for Servatrice Debian


## What will change with this Pull Request?
- Update button labels in index.html
- Remove hard coded `Ubuntu24` in githubAPI.js
- Hardcode `Debian13`

## Question

Does the Ubuntu line in githubAPI.js need to be updated to `Ubuntu26` or will it simply fetch the latest version without a number like the Fedora and Debian lines?