### PR TITLE
Update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2


### PR DESCRIPTION
Github is [setting all actions to run on Node24 by default ](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)on June 2, 2026 and will discontinue Node20 in September. As far as I can tell, checkout v4 isn't able to run on Node24, while v5 and v6 can. We currently use v6 in the Cockatrice repo so it makes sense to update to it here in advance of the Node change.